### PR TITLE
Removed "bottom: 0" from ".ui-resizable-sw"

### DIFF
--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -87,7 +87,7 @@ $animation_speed: .3s !default;
     > .ui-resizable-e  { cursor: e-resize;  width: 10px; top: 15px; bottom: 15px; }
     > .ui-resizable-se { cursor: se-resize; width: 20px; height: 20px;}
     > .ui-resizable-s  { cursor: s-resize;  height: 10px; left: 25px; bottom: 0; right: 25px; }
-    > .ui-resizable-sw { cursor: sw-resize; width: 20px; height: 20px; bottom: 0; }
+    > .ui-resizable-sw { cursor: sw-resize; width: 20px; height: 20px;}
     > .ui-resizable-w  { cursor: w-resize;  width: 10px; top: 15px; bottom: 15px; }
 
     &.ui-draggable-dragging {


### PR DESCRIPTION
See issue #1853 for details.
In summary: this proposed change aligns the -sw grid-item sizing icon to have the same 4px bottom as its -se variant. I can confirm this works on Chrome, Edge and Firefox with no performance issues.